### PR TITLE
Return email addresses on iOS

### DIFF
--- a/src/ios/CDVContact.swift
+++ b/src/ios/CDVContact.swift
@@ -999,6 +999,13 @@ let kW3ContactUrls = "urls"
             if value != nil {
                 nc[kW3ContactPhoneNumbers] = value
             }
+
+            // emails array
+            // NSLog(@"getting emails");
+            value = extractMultiValue(kW3ContactEmails)
+            if value != nil {
+                nc[kW3ContactEmails] = value
+            }
             return nc
         } else {
             // if no returnFields specified, W3C says to return empty contact (but Cordova will at least return id)

--- a/src/ios/CDVContacts.swift
+++ b/src/ios/CDVContacts.swift
@@ -50,7 +50,8 @@ class CDVNewContactsController: CNContactViewController {
                                                     CNContactNamePrefixKey as CNKeyDescriptor,
                                                     CNContactNameSuffixKey as CNKeyDescriptor,
                                                     CNContactPhoneNumbersKey as CNKeyDescriptor,
-                                                    CNContactTypeKey as CNKeyDescriptor]
+                                                    CNContactTypeKey as CNKeyDescriptor,
+                                                    CNContactEmailAddressesKey as CNKeyDescriptor]
     
     // overridden to clean up Contact statics
     override func onAppTerminate() {


### PR DESCRIPTION
### Platforms affected

* iOS

### What does this PR do?

This PR returns email addresses for iOS contacts.

### What testing has been done on this change?

We use the `find` method like so (transposed slightly from Ionic/Typescript)

```ts
let fields: ContactFieldType[] = ["phoneNumbers", "emails"];
let options: IContactFindOptions = {
	filter: "",
	multiple: true,
};
let results = contacts.find(fields, options);
```

Resolves https://github.com/codeborne/cordova-plugin-contacts/issues/3.
